### PR TITLE
feat(tooltip): add badge prop to tooltip

### DIFF
--- a/packages/components/src/components/tooltip/src/index.tsx
+++ b/packages/components/src/components/tooltip/src/index.tsx
@@ -45,7 +45,7 @@ const StyledArrow = styled(TooltipPrimitive.Arrow, {
 
 export interface ToolTipContentProps
   extends Omit<TooltipPrimitive.TooltipContentProps, "css"> {
-  badge?: number;
+  badge?: string;
 }
 
 export const TooltipContent: React.FC<ToolTipContentProps> = ({

--- a/packages/components/src/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/src/components/tooltip/stories/tooltip.stories.tsx
@@ -194,7 +194,7 @@ export const WithBadge: React.FC = () => (
           <InfoCircleIcon decorative size="small" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent badge={3} side="right">
+      <TooltipContent badge="3" side="right">
         Approvals
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Description of the change

Adds badge prop to tooltip. Badge prop can only take a number, and display a green badge when used. This should only be used for tooltips with short content.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
