### PR TITLE
TRUE-247 | fix(dropdown menu): allow sideOffset to be set

### DIFF
--- a/packages/components/src/components/dropdown-menu/src/index.tsx
+++ b/packages/components/src/components/dropdown-menu/src/index.tsx
@@ -15,7 +15,6 @@ export const DropdownMenuContent = styled(DropdownMenuPrimitive.Content, {
   borderRadius: theme.radii[30],
   padding: theme.space[25],
   minWidth: "180px",
-  marginTop: theme.space[10],
   animationDuration: "400ms",
   animationTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
   willChange: "transform, opacity",
@@ -23,6 +22,9 @@ export const DropdownMenuContent = styled(DropdownMenuPrimitive.Content, {
     animationName: slideUpAndFade,
   },
 });
+DropdownMenuContent.defaultProps = {
+  sideOffset: 4,
+};
 
 const dropdownMenuItemStyles = {
   all: "unset",
@@ -64,6 +66,7 @@ export const DropdownMenuItemLeftSlot = styled("div", {
 });
 
 export const DropdownMenuItemRightSlot = styled("div", {
+  display: "flex",
   marginLeft: "auto",
   paddingLeft: theme.space[25],
   color: theme.colors.textMedium,

--- a/packages/components/src/components/dropdown-menu/stories/index.stories.tsx
+++ b/packages/components/src/components/dropdown-menu/stories/index.stories.tsx
@@ -16,6 +16,7 @@ import {
 import { FauxSelectBox } from "../src/FauxSelect";
 import { Button } from "../../button";
 import { Box } from "../../../primitives/box";
+import { Badge } from "../../badge";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -137,6 +138,33 @@ export const DefaultOpen: React.FC = () => (
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
+  </Box>
+);
+
+export const RightSide: React.FC = () => (
+  <Box css={{ position: "absolute", top: 20, left: 20 }}>
+    <Box css={{ marginBottom: "$25" }}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="primary">Open Menu</Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="start" side="right" sideOffset={8}>
+          <DropdownMenuItem as="a" href="#">
+            Recruiter Capacity
+          </DropdownMenuItem>
+          <DropdownMenuItem as="a" href="#">
+            Approved Hires
+          </DropdownMenuItem>
+          <DropdownMenuItem as="a" href="#">
+            Unclaimed Hires
+            <DropdownMenuItemRightSlot>
+              <Badge size="small">3</Badge>
+            </DropdownMenuItemRightSlot>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </Box>
   </Box>
 );
 


### PR DESCRIPTION
## Description of the change

Uses sideOffset instead of a css margin so that the menu can be positioned to the right of the button with a custom offset (for the navigation rewrite).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
