### PR TITLE
TRUE-999 | New line height values

### DIFF
--- a/.changeset/rude-countries-camp.md
+++ b/.changeset/rude-countries-camp.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": minor
+---
+
+[avatar]: lineHeight prop updated to use new key

--- a/.changeset/thirty-moose-yawn.md
+++ b/.changeset/thirty-moose-yawn.md
@@ -1,7 +1,5 @@
 ---
-"@trueplan/forecast-components": minor
 "@trueplan/forecast-theme": minor
 ---
 
 [theme]: new line height values. lineHeight[2] key was removed and value moved to lineHeight[5].
-[avatar]: lineHeight prop updated to use new key

--- a/.changeset/thirty-moose-yawn.md
+++ b/.changeset/thirty-moose-yawn.md
@@ -1,0 +1,7 @@
+---
+"@trueplan/forecast-components": minor
+"@trueplan/forecast-theme": minor
+---
+
+[theme]: new line height values. lineHeight[2] key was removed and value moved to lineHeight[5].
+[avatar]: lineHeight prop updated to use new key

--- a/packages/components/src/components/avatar/src/Avatar.tsx
+++ b/packages/components/src/components/avatar/src/Avatar.tsx
@@ -40,7 +40,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
             <Text
               display="block"
               fontSize="fontSize10"
-              lineHeight="lineHeight2"
+              lineHeight="lineHeight5"
               fontWeight="semiBold"
             >
               {name}
@@ -49,7 +49,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
               <Text
                 display="block"
                 fontSize="fontSize10"
-                lineHeight="lineHeight2"
+                lineHeight="lineHeight5"
                 fontWeight="normal"
               >
                 {title}

--- a/packages/components/src/components/tag/src/styles.ts
+++ b/packages/components/src/components/tag/src/styles.ts
@@ -14,7 +14,7 @@ export const StyledTag = styled("span", {
     size: {
       default: {
         fontSize: theme.fontSizes[10],
-        lineHeight: theme.lineHeights[2],
+        lineHeight: theme.lineHeights[5],
         paddingTop: theme.space[10],
         paddingRight: theme.space[25],
         paddingBottom: theme.space[10],
@@ -22,7 +22,7 @@ export const StyledTag = styled("span", {
       },
       medium: {
         fontSize: theme.fontSizes[20],
-        lineHeight: theme.lineHeights[2],
+        lineHeight: theme.lineHeights[5],
         paddingTop: theme.space[20],
         paddingRight: theme.space[25],
         paddingBottom: theme.space[20],

--- a/packages/components/src/primitives/text/src/index.tsx
+++ b/packages/components/src/primitives/text/src/index.tsx
@@ -14,7 +14,6 @@ export interface TextProps
     | "textRed"
     | "textBlue";
   lineHeight?:
-    | "lineHeight2"
     | "lineHeight5"
     | "lineHeight10"
     | "lineHeight20"

--- a/packages/components/src/primitives/text/src/styles.ts
+++ b/packages/components/src/primitives/text/src/styles.ts
@@ -53,9 +53,6 @@ export const StyledText = styled("span", {
       },
     },
     lineHeight: {
-      lineHeight2: {
-        lineHeight: theme.lineHeights[2],
-      },
       lineHeight5: {
         lineHeight: theme.lineHeights[5],
       },

--- a/packages/theme/src/themes/default/index.ts
+++ b/packages/theme/src/themes/default/index.ts
@@ -191,16 +191,15 @@ export const { styled, css, theme, keyframes, getCssText } = createStitches({
     },
     lineHeights: {
       0: "0", // 0px for icon lineHeight
-      2: "1rem", // 16px
-      5: "1.25rem", // 20px
-      10: "1.375rem", // 22px
+      5: "1rem", // 16px
+      10: "1.25rem", // 20px
       20: "1.5rem", // 24px
-      30: "1.625rem", // 26px
-      40: "1.875rem", // 30px
-      50: "2.125rem", // 34px
-      60: "2.625rem", // 42px
-      70: "3.125rem", // 50px
-      80: "5.625rem", // 90px
+      30: "1.75rem", // 28px
+      40: "2rem", // 32px
+      50: "2.5rem", // 40px
+      60: "3rem", // 48px
+      70: "3.5rem", // 56px
+      80: "6rem", // 99px
     },
     borderWidths: {
       10: "1px",


### PR DESCRIPTION
## Description of the change

> Update line height values in theme. Removed `lineHeight[2]` step from scale, value shifted over to `lineHeight[5]`. Updated `<Avatar />` component to use new key, but value did not change.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
