### PR TITLE
feat(avatar): adds bg color util

### DIFF
--- a/.changeset/cool-emus-notice.md
+++ b/.changeset/cool-emus-notice.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[avatar]: adds helper function to generate an avatar background color using the length of a person's full name

--- a/packages/components/src/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/components/src/components/avatar/__tests__/avatar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { Avatar } from "../src";
-import { getInitialsFromName } from "../src/utils";
+import { getInitialsFromName, getAvatarColor } from "../src/utils";
 
 describe("Avatar", () => {
   describe("Utils", () => {
@@ -11,6 +11,15 @@ describe("Avatar", () => {
         expect(getInitialsFromName("Rich")).toEqual("R");
         expect(getInitialsFromName("Rich Ngozi Bachman")).toEqual("RB");
         expect(getInitialsFromName("Super Long Name Example")).toEqual("SE");
+      });
+    });
+
+    describe("getAvatarColor", () => {
+      it("should return a color name from a person's name", () => {
+        expect(getAvatarColor("Jimmy Tang")).toEqual("sky");
+        expect(getAvatarColor("Rich")).toEqual("yellow");
+        expect(getAvatarColor("Rich Ngozi Bachman")).toEqual("yellow");
+        expect(getAvatarColor("Super Long Name Example")).toEqual("lilac");
       });
     });
   });

--- a/packages/components/src/components/avatar/src/utils.ts
+++ b/packages/components/src/components/avatar/src/utils.ts
@@ -1,3 +1,5 @@
+import type { AvatarColors } from ".";
+
 export const getInitialsFromName = (fullname: string): string => {
   return fullname
     .split(" ")
@@ -9,3 +11,26 @@ export const getInitialsFromName = (fullname: string): string => {
       return previous;
     }, "");
 };
+
+const avatarColorOptions: AvatarColors[] = [
+  "blue",
+  "green",
+  "lilac",
+  "sky",
+  "yellow",
+  "red",
+  "royal",
+];
+
+/**
+ * Generates an avatar background color using the length of a person's full name
+ * @param name: person's full name
+ * @returns AvatarColors
+ *
+ * @example
+ * getAvatarColor("Pam Beesly")
+ * // returns "sky"
+ */
+
+export const getAvatarColor = (name: string): string =>
+  avatarColorOptions[name.length % avatarColorOptions.length];

--- a/packages/components/src/components/avatar/stories/index.stories.tsx
+++ b/packages/components/src/components/avatar/stories/index.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
+import type { AvatarColors } from "../src";
 import { Avatar } from "../src";
 import { Box } from "../../../primitives/box";
 import { Stack } from "../../../layout/stack";
+import { getAvatarColor } from "../src/utils";
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -204,6 +206,35 @@ export const WithName = (): React.ReactNode => {
       />
       <Avatar
         name="Nate Schulte"
+        size="large"
+        showName
+        title="Founding Designer"
+      />
+    </Stack>
+  );
+};
+
+export const WithNameAndRandomBackgroundColor = (): React.ReactNode => {
+  return (
+    <Stack direction="vertical" spacing="$40">
+      <Avatar
+        name="Nate Schulte"
+        // eslint-disable-next-line sonarjs/no-duplicate-string
+        color={getAvatarColor("Nate Schulte") as AvatarColors}
+        size="small"
+        showName
+        title="Founding Designer"
+      />
+      <Avatar
+        name="Nate Schulte"
+        color={getAvatarColor("Nate Schulte") as AvatarColors}
+        size="medium"
+        showName
+        title="Founding Designer"
+      />
+      <Avatar
+        name="Nate Schulte"
+        color={getAvatarColor("Nate Schulte") as AvatarColors}
         size="large"
         showName
         title="Founding Designer"


### PR DESCRIPTION
## Description of the change

> Adds a helper function that generates an avatar background color using the length of a person's full name

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
