### PR TITLE
fix: radio button alignment in firefox

### DIFF
--- a/.changeset/six-seahorses-sniff.md
+++ b/.changeset/six-seahorses-sniff.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[radio]: removes wrapper element around radio button and label components to improve alignment with flexbox.

--- a/packages/components/src/components/radio-group/src/Radio.tsx
+++ b/packages/components/src/components/radio-group/src/Radio.tsx
@@ -7,29 +7,31 @@ import type { RadioProps } from "./types";
 const Radio = React.forwardRef<HTMLButtonElement, RadioProps>(
   ({ children, disabled, id, required, value, ...props }, ref) => {
     return (
-      <Box css={{ display: "flex" }}>
-        <Box css={{ flexShrink: 0 }}>
-          <StyledRadio
-            disabled={disabled}
-            id={id}
-            value={value}
-            required={required}
-            ref={ref}
-            {...props}
-          >
-            <StyledRadioIndicator />
-          </StyledRadio>
-        </Box>
-        <Box css={{ marginLeft: "$20" }}>
-          <Label
-            disabled={disabled}
-            htmlFor={id}
-            marginBottom="space0"
-            radiocheckbox
-          >
-            {children}
-          </Label>
-        </Box>
+      <Box
+        css={{
+          display: "flex",
+          alignItems: "center",
+          columnGap: ".5rem",
+        }}
+      >
+        <StyledRadio
+          disabled={disabled}
+          id={id}
+          value={value}
+          required={required}
+          ref={ref}
+          {...props}
+        >
+          <StyledRadioIndicator />
+        </StyledRadio>
+        <Label
+          disabled={disabled}
+          htmlFor={id}
+          marginBottom="space0"
+          radiocheckbox
+        >
+          {children}
+        </Label>
       </Box>
     );
   }

--- a/packages/components/src/components/radio-group/src/styles.ts
+++ b/packages/components/src/components/radio-group/src/styles.ts
@@ -10,7 +10,6 @@ export const StyledRadio = styled(RadioGroupPrimitive.Item, {
   borderStyle: "solid",
   borderWidth: theme.borderWidths[10],
   height: "16px",
-  marginTop: "4px",
   transition: "border-color 100ms ease-in",
   width: "16px",
   "&:hover": {


### PR DESCRIPTION
- refactor: less nesting to resolve issue in firefox
- docs: adds changeset

## Description of the change

> Fixes alignment issue with radio button and label in Firefox

https://app.asana.com/0/1202137549526336/1202242402477299/f

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
