### PR TITLE
chore: wrap Drag and Drop File component in forwardRef

### DIFF
--- a/.changeset/shaggy-teachers-lie.md
+++ b/.changeset/shaggy-teachers-lie.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": minor
+---
+
+[Drag and Drop File] - Now wrapped in a forwardRef

--- a/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
@@ -27,82 +27,94 @@ type DragAndDropFileContainerProps = {
 };
 
 /** A container that enables users to drag and drop or select file(s) */
-export const DragAndDropFileContainer = ({
-  acceptedFileTypes,
-  Illustration,
-  isLoading,
-  maxFiles,
-  onDrop,
-  RejectIllustration,
-  rejectText,
-  uploadText,
-}: DragAndDropFileContainerProps): JSX.Element => {
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    open,
-    isDragAccept,
-    isDragReject,
-  } = useDropzone({
-    noClick: true,
-    maxFiles,
-    accept: acceptedFileTypes,
-    onDropAccepted: onDrop,
-  });
+const DragAndDropFileContainer = React.forwardRef<
+  HTMLDivElement,
+  DragAndDropFileContainerProps
+>(
+  (
+    {
+      acceptedFileTypes,
+      Illustration,
+      isLoading,
+      maxFiles,
+      onDrop,
+      RejectIllustration,
+      rejectText,
+      uploadText,
+    },
+    ref
+  ) => {
+    const {
+      acceptedFiles,
+      getRootProps,
+      getInputProps,
+      open,
+      isDragAccept,
+      isDragReject,
+    } = useDropzone({
+      noClick: true,
+      maxFiles,
+      accept: acceptedFileTypes,
+      onDropAccepted: onDrop,
+    });
 
-  const containerState = isDragReject
-    ? "rejected"
-    : isDragAccept
-    ? "accepted"
-    : "neutral";
+    const containerState = isDragReject
+      ? "rejected"
+      : isDragAccept
+      ? "accepted"
+      : "neutral";
 
-  const canDisplayIllustration =
-    (isDragReject && RejectIllustration) || (!isDragReject && Illustration);
+    const canDisplayIllustration =
+      (isDragReject && RejectIllustration) || (!isDragReject && Illustration);
 
-  return (
-    <StyledContainer state={containerState} {...getRootProps()}>
-      <input data-testid="dnd-input" {...getInputProps()} />
+    return (
+      <StyledContainer state={containerState} {...getRootProps()} ref={ref}>
+        <input data-testid="dnd-input" {...getInputProps()} />
 
-      {isLoading ? (
-        <>
-          <Spinner
-            label="" // Label would be redundant with text below
-            size="large"
-          />
-          <Text css={{ marginTop: "$30" }}>
-            Checking your file{" "}
-            {acceptedFiles.map((value) => value.name).join(", ")}
-          </Text>
-        </>
-      ) : (
-        <>
-          {canDisplayIllustration && (
-            <Box css={{ marginBottom: "$20" }}>
-              {isDragReject ? RejectIllustration : Illustration}
-            </Box>
-          )}
+        {isLoading ? (
+          <>
+            <Spinner
+              label="" // Label would be redundant with text below
+              size="large"
+            />
+            <Text css={{ marginTop: "$30" }}>
+              Checking your file{" "}
+              {acceptedFiles.map((value) => value.name).join(", ")}
+            </Text>
+          </>
+        ) : (
+          <>
+            {canDisplayIllustration && (
+              <Box css={{ marginBottom: "$20" }}>
+                {isDragReject ? RejectIllustration : Illustration}
+              </Box>
+            )}
 
-          <Text css={{ marginBottom: "$35" }}>
-            {isDragReject ? rejectText : uploadText}
-          </Text>
+            <Text css={{ marginBottom: "$35" }}>
+              {isDragReject ? rejectText : uploadText}
+            </Text>
 
-          <Button
-            variant="secondary"
-            onClick={open}
-            css={
-              isDragAccept
-                ? {
-                    backgroundColor: `${theme.colors.gray20}`,
-                    transition: "none",
-                  }
-                : undefined
-            }
-          >
-            Choose File
-          </Button>
-        </>
-      )}
-    </StyledContainer>
-  );
-};
+            <Button
+              variant="secondary"
+              onClick={open}
+              css={
+                isDragAccept
+                  ? {
+                      backgroundColor: `${theme.colors.gray20}`,
+                      transition: "none",
+                    }
+                  : undefined
+              }
+            >
+              Choose File
+            </Button>
+          </>
+        )}
+      </StyledContainer>
+    );
+  }
+);
+
+DragAndDropFileContainer.displayName = "DragAndDropFileContainer";
+
+export { DragAndDropFileContainer };


### PR DESCRIPTION
## Description of the change

I realized I forgot to wrap the Drag and Drop File component in a forwardRef.

## Testing the change

- [ ] Component should continue to work as expected but now with ref-ability

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
