### PR TITLE
fix(components): added pointer event none to select chevron icon

### DIFF
--- a/.changeset/silver-geckos-invite.md
+++ b/.changeset/silver-geckos-invite.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[Select]: Added `pointer-events: none` to the chevron container in order to fix the select not opening when a user clicks on the icon.

--- a/packages/components/src/components/select/src/Select.tsx
+++ b/packages/components/src/components/select/src/Select.tsx
@@ -38,6 +38,7 @@ const SelectIconWrapper: React.FC = () => (
       top: "50%",
       right: 12,
       marginTop: "-0.313rem",
+      pointerEvents: "none",
     }}
   >
     <ChevronDownIcon decorative size="xxsmall" />


### PR DESCRIPTION
## Description of the change

Fixes the select not opening when a user clicks exactly on the select chevron icon.

![Screen Shot 2022-06-14 at 11 47 06 AM](https://user-images.githubusercontent.com/1350081/173632154-13f5d39d-69d5-48fd-a624-6ab0770fdaf1.png)

Asana task: https://app.asana.com/0/1202370860995804/1202445468761992/f

## Testing the change

- [ ] Open Storybook and go to the Select component
- [ ] Click exactly on the chevron icon and make sure the select opens

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
