### PR TITLE
Feat/add loading illustration

### DIFF
--- a/.changeset/swift-kids-join.md
+++ b/.changeset/swift-kids-join.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[Drag and Drop File Container] Added ability to pass in a loading illustration

--- a/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
@@ -16,12 +16,14 @@ type DragAndDropFileContainerProps = {
   acceptedFileTypes?: Record<string, string[]>;
   /** Text that displays about what a user should do */
   uploadText: string;
-  /** Illustration to display in the container */
-  Illustration?: JSX.Element;
   /** Text that displays when a user tries to drag a file type that is not accepted */
   rejectText: string;
+  /** Illustration to display in the container */
+  Illustration?: JSX.Element;
   /** Illustration to display when a user tries to drag a file type that is not accepted */
   RejectIllustration?: JSX.Element;
+  /** Illustration to display during the loading state */
+  LoadingIllustration?: JSX.Element;
   /** Shows loading state */
   isLoading?: boolean;
 };
@@ -34,11 +36,12 @@ const DragAndDropFileContainer = React.forwardRef<
   (
     {
       acceptedFileTypes,
-      Illustration,
       isLoading,
       maxFiles,
       onDrop,
+      Illustration,
       RejectIllustration,
+      LoadingIllustration,
       rejectText,
       uploadText,
     },
@@ -73,6 +76,7 @@ const DragAndDropFileContainer = React.forwardRef<
 
         {isLoading ? (
           <>
+            <Box css={{ marginBottom: "$20" }}>{LoadingIllustration}</Box>
             <Spinner
               label="" // Label would be redundant with text below
               size="large"

--- a/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/src/index.tsx
@@ -76,7 +76,9 @@ const DragAndDropFileContainer = React.forwardRef<
 
         {isLoading ? (
           <>
-            <Box css={{ marginBottom: "$20" }}>{LoadingIllustration}</Box>
+            {LoadingIllustration && (
+              <Box css={{ marginBottom: "$20" }}>{LoadingIllustration}</Box>
+            )}
             <Spinner
               label="" // Label would be redundant with text below
               size="large"

--- a/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
@@ -72,7 +72,6 @@ WithIllustrations.args = {
       className="chromatic-ignore"
     />
   ),
-  isLoading: true,
 };
 WithIllustrations.parameters = {
   docs: {

--- a/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
@@ -72,6 +72,7 @@ WithIllustrations.args = {
       className="chromatic-ignore"
     />
   ),
+  isLoading: true,
 };
 WithIllustrations.parameters = {
   docs: {
@@ -83,4 +84,16 @@ WithIllustrations.parameters = {
 export const Loading = Template.bind({});
 Loading.args = {
   isLoading: true,
+};
+
+export const LoadingWithIllustration = Template.bind({});
+LoadingWithIllustration.args = {
+  isLoading: true,
+  LoadingIllustration: (
+    <img
+      src="https://www.placecage.com/gif/130/100"
+      alt="Nicholas Cage"
+      className="chromatic-ignore"
+    />
+  ),
 };

--- a/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
@@ -65,6 +65,13 @@ WithIllustrations.args = {
       className="chromatic-ignore"
     />
   ),
+  LoadingIllustration: (
+    <img
+      src="https://www.placecage.com/gif/130/100"
+      alt="Nicholas Cage"
+      className="chromatic-ignore"
+    />
+  ),
 };
 WithIllustrations.parameters = {
   docs: {


### PR DESCRIPTION
## Description of the change

Adds support to the Drag and Drop File Container component to be able to provide your own illustration during the loading state.

![image](https://user-images.githubusercontent.com/3478163/173917736-45dd5c70-0af5-445e-95e9-360270a464fb.png)

## Testing the change

- [ ] Check out the loading with illustration story

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] Issue from Asana has a link to this pull request
