### PR TITLE
fix: drag and drop file container losing hover when dragging over image or button

### DIFF
--- a/.changeset/poor-clocks-laugh.md
+++ b/.changeset/poor-clocks-laugh.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[Drag and Drop File Container] Fix styling when draging over the image or button in the container

--- a/packages/components/src/components/drag-and-drop-file-container/src/styles.ts
+++ b/packages/components/src/components/drag-and-drop-file-container/src/styles.ts
@@ -19,10 +19,16 @@ export const StyledContainer = styled("div", {
       accepted: {
         backgroundColor: theme.colors.gray20,
         borderColor: baseBorderColor,
+        "*": {
+          pointerEvents: "none",
+        },
       },
       rejected: {
         borderColor: theme.colors.red,
         backgroundColor: theme.colors.red10,
+        "*": {
+          pointerEvents: "none",
+        },
       },
     },
   },

--- a/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
+++ b/packages/components/src/components/drag-and-drop-file-container/stories/index.stories.tsx
@@ -21,7 +21,7 @@ const Template: ComponentStory<typeof DragAndDropFileContainer> = ({
   const [files, setFiles] = useState<File[]>([]);
 
   return (
-    <Box>
+    <Box css={{ maxWidth: "700px", height: "400px", width: "100%" }}>
       <DragAndDropFileContainer
         uploadText={uploadText}
         acceptedFileTypes={acceptedFileTypes}
@@ -36,13 +36,17 @@ const Template: ComponentStory<typeof DragAndDropFileContainer> = ({
       <Text display="block" css={{ marginTop: "20px" }}>
         Accepted Files:
       </Text>
-      <ul>
-        {files.map((file) => (
-          <li key={file.name}>
-            {file.name} - {file.size} bytes
-          </li>
-        ))}
-      </ul>
+      {files.length > 0 ? (
+        <ul>
+          {files.map((file) => (
+            <Box as="li" key={file.name} css={{ marginLeft: "$35" }}>
+              {file.name} - {file.size} bytes
+            </Box>
+          ))}
+        </ul>
+      ) : (
+        "No accepted files"
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Description of the change

The Drag and Drop file container was losing it's drag state when you drag a file over the image or the button inside of the container. Turned off pointer events for all elements inside the container once a drag in the container is active.

I also just cleaned up the stories so that it isn't as ugly. 😬 

## Testing the change

- [ ] Try dragging a file over the image or button inside of the component container

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
