### PR TITLE
fix: use automaton user PAT for package versions pr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,12 @@ jobs:
       - name: "Creates Pull Request or Publish to npm"
         uses: changesets/action@v1
         with:
-          version: yarn changeset version
+          version: yarn changeset version && yarn install --mode=update-lockfile
           publish: yarn changeset publish
           commit: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMATON_GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
   vrt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of the change

Found a potential fix for the package versions pr not starting the github actions. https://github.com/changesets/action/issues/99

This also adds the yarn installs step to the changeset version script, which should fix our yarn.lock file updates when needed. More details: https://github.com/changesets/changesets/issues/421#issuecomment-1030120601

Asana task: https://app.asana.com/0/1202225918873892/1202398053261519/f

## Testing the change

- [ ] Unfortunately no way to test this until we merge a package change to main.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
