### PR TITLE
feat(components): add prop that controls visibility of toggle label text

### DIFF
--- a/.changeset/loud-beans-pay.md
+++ b/.changeset/loud-beans-pay.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[Toggle]: add prop to show the label text. `showLabelText` defaults to true.

--- a/packages/components/src/components/drawer/stories/index.stories.tsx
+++ b/packages/components/src/components/drawer/stories/index.stories.tsx
@@ -20,7 +20,7 @@ export default {
   chromatic: { pauseAnimationAtEnd: true },
 };
 
-export const Default: React.FC = () => {
+export const Default = (): JSX.Element => {
   return (
     <Box css={{ height: "1000px", width: "1350px" }}>
       <Drawer defaultOpen>
@@ -52,7 +52,7 @@ export const Default: React.FC = () => {
   );
 };
 
-export const NoPaddingOnBody: React.FC = () => {
+export const NoPaddingOnBody = (): JSX.Element => {
   return (
     <Box css={{ height: "1000px", width: "1350px" }}>
       <Drawer defaultOpen>
@@ -84,7 +84,7 @@ export const NoPaddingOnBody: React.FC = () => {
   );
 };
 
-export const OverflowBodyContent: React.FC = () => {
+export const OverflowBodyContent = (): JSX.Element => {
   return (
     <Box css={{ height: "1000px", width: "1350px" }}>
       <Drawer defaultOpen>

--- a/packages/components/src/components/toggle/src/index.tsx
+++ b/packages/components/src/components/toggle/src/index.tsx
@@ -3,6 +3,7 @@ import { Stack } from "../../../layout/stack";
 import { StyledToggle, StyledCircle, StyledLabel } from "./styles";
 import type { ToggleProps } from "./types";
 
+/** A control that allows the user to toggle between checked and not checked. */
 const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
   (
     {
@@ -13,6 +14,7 @@ const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
       onCheckedChange,
       required,
       value = "Off",
+      showLabelText = true,
       ...props
     },
     ref
@@ -32,9 +34,11 @@ const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
         >
           <StyledCircle />
         </StyledToggle>
-        <StyledLabel htmlFor={id}>
-          {checked || defaultChecked ? "On" : "Off"}
-        </StyledLabel>
+        {showLabelText && (
+          <StyledLabel htmlFor={id}>
+            {checked || defaultChecked ? "On" : "Off"}
+          </StyledLabel>
+        )}
       </Stack>
     );
   }

--- a/packages/components/src/components/toggle/src/types.ts
+++ b/packages/components/src/components/toggle/src/types.ts
@@ -2,11 +2,20 @@ import type React from "react";
 
 export interface ToggleProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "css"> {
+  /** The controlled state of the toggle. Must be used in conjunction with onCheckedChange. */
   checked?: boolean;
+  /** The state of the toggle when it is initially rendered. Use when you do not need to control its state. */
   defaultChecked?: boolean;
+  /** The id for the toggle. */
   id: string;
+  /** The name for the toggle. */
   name?: string;
+  /** Event handler called when the state of the toggle changes. */
   onCheckedChange?: (checked: boolean) => void;
+  /** When true, indicates that the user must check the toggle before the owning form can be submitted. */
   required?: boolean;
+  /** The value given as data when submitted with a name. Either On or Off. */
   value?: "On" | "Off";
+  /** Show the label On/Off text to the right of the toggle. Defaults to true. */
+  showLabelText?: boolean;
 }

--- a/packages/components/src/components/toggle/stories/index.stories.tsx
+++ b/packages/components/src/components/toggle/stories/index.stories.tsx
@@ -36,3 +36,18 @@ export const On: React.FC = () => {
     />
   );
 };
+
+export const HiddenLabelText: React.FC = () => {
+  const [checked, setChecked] = React.useState(true);
+  const id = useUID();
+  return (
+    <Toggle
+      id={id}
+      checked={checked}
+      onCheckedChange={() =>
+        setChecked((prevIsChecked) => (prevIsChecked === true ? false : true))
+      }
+      showLabelText={false}
+    />
+  );
+};


### PR DESCRIPTION
## Description of the change

Adds a prop and story for controlling the visibility of the toggle label text. This is needed for some of the org chart work.

![Screen Shot 2022-06-23 at 12 44 43 PM](https://user-images.githubusercontent.com/1350081/175361745-ca59eaa1-5e28-4fe6-a848-197af29416ae.png)

Asana task: N/A

## Testing the change

- [ ] Go to storybook
- [ ] Verify there is a story for the toggle text being hidden

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
