### PR TITLE
fix: specify table font stylings

### DIFF
--- a/.changeset/five-months-remember.md
+++ b/.changeset/five-months-remember.md
@@ -1,0 +1,5 @@
+---
+"@trueplan/forecast-components": patch
+---
+
+[Table] Fix table text stylings

--- a/packages/components/src/components/table/src/styles.ts
+++ b/packages/components/src/components/table/src/styles.ts
@@ -2,6 +2,8 @@ import { styled, theme } from "@trueplan/forecast-theme";
 
 const border = `1px solid ${theme.colors.gray40}`;
 const cellPadding = `$30 $35`;
+const fontColor = "$gray80";
+const fontSize = "$20";
 
 export const StyledTable = styled("table", {
   border,
@@ -28,9 +30,15 @@ export const StyledTR = styled("tr", { borderBottom: border });
 
 export const StyledTD = styled("td", {
   padding: cellPadding,
+  fontWeight: "$medium",
+  fontSize: fontSize,
+  color: fontColor,
 });
 
 export const StyledTH = styled("th", {
   padding: cellPadding,
   textAlign: "left",
+  fontWeight: "$semiBold",
+  fontSize: fontSize,
+  color: fontColor,
 });


### PR DESCRIPTION
## Description of the change

By not being explicit about some of the text stylings, the text in the table was rendering differently when used in the app.

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/3478163/175555674-d25ecc2e-0e5e-47e5-9992-1811d1133204.png">

## Testing the change

- [ ] Check out the table story

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
