### PR TITLE
Add modal to the types

### DIFF
--- a/packages/components/src/components/drawer/src/types.ts
+++ b/packages/components/src/components/drawer/src/types.ts
@@ -4,6 +4,7 @@ export interface DrawerProps {
   children: React.ReactNode;
   defaultOpen?: boolean;
   open?: boolean;
+  modal?: boolean;
   onOpenChange?: (open: boolean) => void;
   id?: string;
 }


### PR DESCRIPTION
## Description of the change

`Drawer` component type is missing a `modal` property  (which it does support)

<img width="593" alt="image" src="https://user-images.githubusercontent.com/6873202/177545683-5860004d-b01e-48b6-afe9-d53866f6f7cb.png">

## Testing the change

- [x] Make sure that when using the `Drawer` component in code,  `modal={false}` property does not show the typescript error

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Non-Breaking Change (change to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from Asana has a link to this pull request
